### PR TITLE
Add $CLOJURESCRIPT_HOME/lib/ to classpath

### DIFF
--- a/cljs-watch
+++ b/cljs-watch
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-CLJS_LIB=$CLOJURESCRIPT_HOME/lib/*
+CLJS_LIB=$CLOJURESCRIPT_HOME/lib/
+CLJS_LIB_JARS=$CLOJURESCRIPT_HOME/lib/*
 CLJS_SRC=$CLOJURESCRIPT_HOME/src/clj
 CLJS_CLJS=$CLOJURESCRIPT_HOME/src/cljs
 
-exec java -server -Xmx2G -Xms2G -Xmn256m -cp "${CLJS_LIB}:${CLJS_SRC}:${CLJS_CLJS}:lib/*:src/" clojure.main -e \
+exec java -server -Xmx2G -Xms2G -Xmn256m -cp "${CLJS_LIB}:${CLJS_LIB_JARS}:${CLJS_SRC}:${CLJS_CLJS}:lib/*:src/" clojure.main -e \
 "
 (use '[clojure.java.io :only [file]])
 (require '[cljs.closure :as cljsc])


### PR DESCRIPTION
This allows clj files in lib that contain compiler macros to be used.
