### PR TITLE
Added ability to compile .clj files with {:generic true} in metadata.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject cljs-watch "1.0.0-SNAPSHOT"
-  :description "FIXME: write description"
+  :description "The Clojurescript compilation watcher."
   :main cljs-watch.core
-  :dependencies [[org.clojure/clojure "1.3.0-beta1"]
+  :dependencies [[org.clojure/clojure "1.3.0"]
                  [cljs-compiler-jar "0.1.0-SNAPSHOT"]])


### PR DESCRIPTION
I submit this as a first stab at a method of sharing code between clojure dialects. All `.clj` source files with `:generic <truthy-val>` in the namespace metadata:

```
(ns clojure.example
  {:generic true}
  (:use ...))
```

will be passed into the clojurescript compiler.
