### PR TITLE
Enable disabling of compile time optimizations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ cljs-watch cljs-src/ '{:optimizations :none :output-to "test.js"}'
 * the default output-to is set to `resources/public/cljs/bootstrap.js`
 * it will add the local `lib/` to your classpath when you run it, allowing you to have other cljs deps in that folder
 * to add custom macros, you can use create a folder called `cljs-macros/` from the root directory and add your macros there. You can also put macros in `CLOJURESCRIPT_HOME/lib/` to have them globally available.
+* `:optimizations` is set to `:simple` by default. you can disable any optimization by passing `:none` as the value.
 
 ## License
 

--- a/src/cljs_watch/core.clj
+++ b/src/cljs_watch/core.clj
@@ -84,9 +84,17 @@
                          (catch Exception e (println e))))]
       {:source source :options options}))
 
+   (defn get-opts
+     [options]
+     (let [ret (merge default-opts options)]
+       ;; Remove the :optimizations key if it's  :none
+       (if (= (:optimizations ret) :none)
+         (dissoc ret :optimizations)
+         ret)))
+  
   (let [{:keys [source options]} (transform-cl-args *command-line-args*)
         src-dir (or source "src/")
-        opts (merge default-opts options)]
+        opts (get-opts options)]
     (.mkdirs (file (:output-dir opts)))
     (watcher-print "Building ClojureScript files in ::" src-dir)
     (compile-cljs src-dir opts)


### PR DESCRIPTION
Currently, :simple is the default optimization in cljs_watch. The README shows an example where :none is passed as an option but that breaks the build process.
This patch lets the user pass :none as the optimization and cljs_watch then actually disables any optimization during the build step.
