### PR TITLE
Added system bell or custom command upon completion. Allowed to set custom classpath using CLASSPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pom.xml
 /classes/
 .lein-failures
 .lein-deps-sum
+*.swp

--- a/README.md
+++ b/README.md
@@ -13,13 +13,20 @@ Put `cljs-watch` on your $PATH (such as in /usr/local/bin) and then simply run i
 cljs-watch
 
 #it can also take a directory and compile options
-cljs-watch cljs-src/ '{:optimizations :none :output-to "test.js"}'
+cljs-watch -s cljs-src/ '{:optimizations :none :output-to "test.js"}'
+
+#you can enable terminal bell ringing or even a custom command upon completed compile
+cljs-watch -b -s cljs-src/
+cljs-watch -c 'growlnotify -m compile-done cljs-watch' -s cljs-src/
 ```
 
 ## Notes
 * the default output-to is set to `resources/public/cljs/bootstrap.js`
 * it will add the local `lib/` to your classpath when you run it, allowing you to have other cljs deps in that folder
 * to add custom macros, you can use create a folder called `cljs-macros/` from the root directory and add your macros there. You can also put macros in `CLOJURESCRIPT_HOME/lib/` to have them globally available.
+* you can also place macros somewhere in your classpath and make sure the CLASSPATH environment variable is set and exported accordingly
+
+* use space with care in the bell command, system exec does not handle it well
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Put `cljs-watch` on your $PATH (such as in /usr/local/bin) and then simply run i
 cljs-watch
 
 #it can also take a directory and compile options
-cljs-watch -s cljs-src/ '{:optimizations :none :output-to "test.js"}'
+cljs-watch -s cljs-src/ '{:optimizations :simple :pretty-print true :output-to "test.js"}'
 
 #you can enable terminal bell ringing or even a custom command upon completed compile
 cljs-watch -b -s cljs-src/

--- a/cljs-watch
+++ b/cljs-watch
@@ -8,7 +8,15 @@ LOCAL_LIB_JARS=lib/*
 LOCAL_LIB=lib/
 LOCAL_MACROS=cljs-macros/
 
-exec java -server -cp "${CLJS_LIB}:${CLJS_LIB_JARS}:${CLJS_SRC}:${CLJS_CLJS}:${LOCAL_LIB}:${LOCAL_LIB_JARS}:${LOCAL_MACROS}" clojure.main -e \
+CLJSC_CP="${CLJS_LIB}:${CLJS_LIB_JARS}:${CLJS_SRC}:${CLJS_CLJS}:${LOCAL_LIB}:${LOCAL_LIB_JARS}:${LOCAL_MACROS}"
+
+if test $1 == "-cp"
+then
+  CLJSC_CP=$CLJSC_CP:$2
+  shift; shift
+fi
+
+exec java -server -cp "$CLJSC_CP" clojure.main -e \
 "
 (use '[clojure.java.io :only [file]])
 (require '[cljs.closure :as cljsc])

--- a/cljs-watch
+++ b/cljs-watch
@@ -172,9 +172,7 @@ exec java -server clojure.main -e \
           f (SimpleDateFormat. \"HH:mm:ss\")]
       (.format f (.getTime c))))
 
-  (def default-opts {:optimizations :simple
-                     :pretty-print true
-                     :output-dir \"resources/public/cljs/\"
+  (def default-opts {:output-dir \"resources/public/cljs/\"
                      :output-to \"resources/public/cljs/bootstrap.js\"})
 
   (def ANSI-CODES

--- a/cljs-watch
+++ b/cljs-watch
@@ -9,7 +9,7 @@ LOCAL_LIB=lib/
 LOCAL_MACROS=cljs-macros/
 
 CLJSC_CP="${CLJS_LIB}:${CLJS_LIB_JARS}:${CLJS_SRC}:${CLJS_CLJS}:${LOCAL_LIB}:${LOCAL_LIB_JARS}:${LOCAL_MACROS}"
-export CLASSPATH=$CLASSPATH:$CLJSC_CP
+export CLASSPATH="${CLASSPATH}:${CLJSC_CP}"
 
 # Remove cmnd from args list
 shift;

--- a/cljs-watch
+++ b/cljs-watch
@@ -9,17 +9,16 @@ LOCAL_LIB=lib/
 LOCAL_MACROS=cljs-macros/
 
 CLJSC_CP="${CLJS_LIB}:${CLJS_LIB_JARS}:${CLJS_SRC}:${CLJS_CLJS}:${LOCAL_LIB}:${LOCAL_LIB_JARS}:${LOCAL_MACROS}"
+export CLASSPATH=$CLASSPATH:$CLJSC_CP
 
-if test $1 == "-cp"
-then
-  CLJSC_CP=$CLJSC_CP:$2
-  shift; shift
-fi
+# Remove cmnd from args list
+shift;
 
-exec java -server -cp "$CLJSC_CP" clojure.main -e \
+exec java -server clojure.main -e \
 "
 (use '[clojure.java.io :only [file]])
 (require '[cljs.closure :as cljsc])
+(require '[clojure.tools.cli :as cli])
 
 (do
   (import '[java.util Calendar])
@@ -92,26 +91,50 @@ exec java -server -cp "$CLJSC_CP" clojure.main -e \
     (print \"    \" (style text :green) \"\n\")
     (flush))
 
-  (defn transform-cl-args
-    [args]
-    (let [source (first args)
-          opts-string (apply str (interpose \" \" (rest args)))
-          options (when (> (count opts-string) 1)
-                    (try (read-string opts-string)
-                      (catch Exception e (println e))))]
-      {:source source :options options}))
+  (defn- parse-options [extra]
+    (let [opts-string (apply str (interpose \" \" extra))]
+      (if (empty? opts-string)
+        {}
+        (try (let [opts (read-string opts-string)]
+                (if (map? opts)
+                  opts
+                  (do
+                    (println \"cljs options must be in map syntax\")
+                    {})))
+          (catch Exception e (println e))))))
 
-  (let [{:keys [source options]} (transform-cl-args *command-line-args*)
-        src-dir (or source \"src/\")
-        opts (merge default-opts options)]
-    (watcher-print \"Building ClojureScript files in ::\" src-dir)
-    (compile-cljs src-dir opts)
-    (status-print \"[done]\")
-    (watcher-print \"Waiting for changes\n\")
-    (while true
-      (Thread/sleep 1000)
-      (when (files-updated? src-dir)
-        (watcher-print \"Compiling updated files...\")
-        (compile-cljs src-dir opts)
-        (status-print \"[done]\")))))
-" $1 $*
+  (defn nop [])
+  (defn- create-done-fn [argsmap]
+    (if (:bell argsmap)
+      (if-let [cmd (:bell-cmd argsmap)]
+        #(.exec (Runtime/getRuntime) cmd)
+        #(do (print \\u0007) (flush))
+      )
+      nop))
+
+  (defn transform-cl-args [args]
+    (let [[argmap extra] (cli/cli args
+            [\"-s\" \"--source\"    \"Source file or directory\" :default \"src/\"]
+            [\"-b\" \"--bell\"      \"Uses system beep to indicate a finished compile\" :flag true]
+            [\"-c\" \"--bell-cmd\"  \"Use this to customize the beep command\"])
+          options (parse-options extra)]
+        (assoc argmap :options options)))
+
+  (let [
+    argsmap (transform-cl-args *command-line-args*)
+    {src-dir :source, :keys [options]} argsmap
+    donefn (create-done-fn argsmap)
+    opts (merge default-opts options)]
+      (.mkdirs (file (:output-dir opts)))
+      (watcher-print \"Building ClojureScript files in ::\" src-dir)
+      (compile-cljs src-dir opts)
+      (status-print \"[done]\")
+      (watcher-print \"Waiting for changes\n\")
+      (while true
+        (Thread/sleep 1000)
+        (when (files-updated? src-dir)
+          (watcher-print \"Compiling updated files...\")
+          (compile-cljs src-dir opts)
+          (status-print \"[done]\")
+          (donefn)))))
+" $*

--- a/cljs-watch
+++ b/cljs-watch
@@ -11,14 +11,157 @@ LOCAL_MACROS=cljs-macros/
 CLJSC_CP="${CLJS_LIB}:${CLJS_LIB_JARS}:${CLJS_SRC}:${CLJS_CLJS}:${LOCAL_LIB}:${LOCAL_LIB_JARS}:${LOCAL_MACROS}"
 export CLASSPATH="${CLASSPATH}:${CLJSC_CP}"
 
-# Remove cmnd from args list
-shift;
-
 exec java -server clojure.main -e \
 "
+; Dependency: clojure.tools.cli START
+; License
+; 
+; Copyright (c) Rich Hickey and contributors. All rights reserved.
+; 
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+; which can be found in the file epl.html at the root of this distribution.
+; By using this software in any fashion, you are agreeing to be bound by the
+; terms of this license. You must not remove this notice, or any other, from
+; this software.
+; 
+(ns ^{:author \"Gareth Jones\"}
+  clojure.tools.cli
+  (:use [clojure.string :only (replace)]
+        [clojure.pprint :only (pprint cl-format)])
+  (:refer-clojure :exclude [replace]))
+
+(do
+(defn- build-doc [{:keys [switches docs default]}]
+  [(apply str (interpose \", \" switches))
+   (or (str default) \"\")
+   (or docs \"\")])
+
+(defn- banner-for [specs]
+  (println \"Usage:\")
+  (println)
+  (let [docs (into (map build-doc specs)
+                   [[\"--------\" \"-------\" \"----\"]
+                    [\"Switches\" \"Default\" \"Desc\"]])
+        max-cols (->> (for [d docs] (map count d))
+                      (apply map (fn [& c] (apply vector c)))
+                      (map #(apply max %)))
+        vs (for [d docs]
+             (mapcat (fn [& x] (apply vector x)) max-cols d))]
+    (doseq [v vs]
+      (cl-format true \"~{ ~vA  ~vA  ~vA ~}\" v)
+      (prn))))
+
+(defn- name-for [k]
+  (replace k #\"^--no-|^--\\[no-\]|^--|^-\" \"\"))
+
+(defn- flag-for [^String v]
+  (not (.startsWith v \"--no-\")))
+
+(defn- opt? [^String x]
+  (.startsWith x \"-\"))
+
+(defn- flag? [^String x]
+  (.startsWith x \"--[no-]\"))
+
+(defn- end-of-args? [x]
+  (= \"--\" x))
+
+(defn- spec-for
+  [arg specs]
+  (->> specs
+       (filter (fn [s]
+                   (let [switches (set (s :switches))]
+                     (contains? switches arg))))
+       first))
+
+(defn- default-values-for
+  [specs]
+  (into {} (for [s specs] [(s :name) (s :default)])))
+
+(defn- apply-specs
+  [specs args]
+  (loop [options    (default-values-for specs)
+         extra-args []
+         args       args]
+    (if-not (seq args)
+      [options extra-args]
+      (let [opt  (first args)
+            spec (spec-for opt specs)]
+        (cond
+         (end-of-args? opt)
+         (recur options (into extra-args (vec (rest args))) nil)
+
+         (and (opt? opt) (nil? spec))
+         (throw (Exception. (str \"'\" opt \"' is not a valid argument\")))
+         
+         (and (opt? opt) (spec :flag))
+         (recur (assoc options (spec :name) (flag-for opt))
+                extra-args
+                (rest args))
+
+         (opt? opt)
+         (recur (assoc options (spec :name) ((spec :parse-fn) (second args)))
+                extra-args
+                (drop 2 args))
+
+         :default
+         (recur options (conj extra-args (first args)) (rest args)))))))
+
+(defn- switches-for
+  [switches flag]
+  (-> (for [^String s switches]
+        (cond
+         (and flag (flag? s))            [(replace s #\"\\[no-\]\" \"no-\") (replace s #\"\[no-\]\" \"\")]
+         (and flag (.startsWith s \"--\")) [(replace s #\"--\" \"--no-\") s]
+         :default                        [s]))
+      flatten))
+
+(defn- generate-spec
+  [raw-spec]
+  (let [[switches raw-spec] (split-with #(and (string? %) (opt? %)) raw-spec)
+        [docs raw-spec]     (split-with string? raw-spec)
+        options             (apply hash-map raw-spec)
+        aliases             (map name-for switches)
+        flag                (or (flag? (last switches)) (options :flag))]
+    (merge {:switches (switches-for switches flag)
+            :docs     (first docs)
+            :aliases  (set aliases)
+            :name     (keyword (last aliases))
+            :parse-fn identity
+            :default  (if flag false nil)
+            :flag     flag}
+           options)))
+
+(defn cli
+  \"Parse the provided args using the given specs. Specs are vectors
+  describing a command line argument. For example:
+
+  [\\\"-p\\\" \\\"--port\\\" \\\"Port to listen on\\\" :default 3000 :parse-fn #(Integer/parseInt %)]
+
+  First provide the switches (from least to most specific), then a doc
+  string, and pairs of options.
+
+  Valid options are :default, :parse-fn, and :flag. See
+  https://github.com/clojure/tools.cli/blob/master/README.md for more
+  detailed examples.
+
+  Returns a vector containing a map of the parsed arguments, a vector
+  of extra arguments that did not match known switches, and a
+  documentation banner to provide usage instructions.\"
+  [args & specs]
+  (let [specs (map generate-spec specs)]
+    (let [[options extra-args] (apply-specs specs args)
+          banner  (with-out-str (banner-for specs))]
+      [options extra-args banner])))
+  \"initialized tools cli\"
+)
+; clojure.tools.cli END
+
+(ns ^{:author \"ibdknox (Chris Granger)\"} cljs_watch)
 (use '[clojure.java.io :only [file]])
 (require '[cljs.closure :as cljsc])
-(require '[clojure.tools.cli :as cli])
+(alias 'cli 'clojure.tools.cli)
 
 (do
   (import '[java.util Calendar])
@@ -106,17 +249,17 @@ exec java -server clojure.main -e \
   (defn nop [])
   (defn- create-done-fn [argsmap]
     (if (:bell argsmap)
+      #(do (print \\u0007) (flush))
       (if-let [cmd (:bell-cmd argsmap)]
         #(.exec (Runtime/getRuntime) cmd)
-        #(do (print \\u0007) (flush))
-      )
-      nop))
+        nop
+      )))
 
   (defn transform-cl-args [args]
     (let [[argmap extra] (cli/cli args
             [\"-s\" \"--source\"    \"Source file or directory\" :default \"src/\"]
             [\"-b\" \"--bell\"      \"Uses system beep to indicate a finished compile\" :flag true]
-            [\"-c\" \"--bell-cmd\"  \"Use this to customize the beep command\"])
+            [\"-c\" \"--bell-cmd\"  \"Use this to customize the beep command e.g. growlnotify -m compile_done cljs-watch\"])
           options (parse-options extra)]
         (assoc argmap :options options)))
 
@@ -129,6 +272,7 @@ exec java -server clojure.main -e \
       (watcher-print \"Building ClojureScript files in ::\" src-dir)
       (compile-cljs src-dir opts)
       (status-print \"[done]\")
+      (donefn)
       (watcher-print \"Waiting for changes\n\")
       (while true
         (Thread/sleep 1000)
@@ -137,4 +281,8 @@ exec java -server clojure.main -e \
           (compile-cljs src-dir opts)
           (status-print \"[done]\")
           (donefn)))))
-" $*
+" cljs-watch "$@"
+# - The quoted "$@" is important in order to handle cli arguments with spaces correctly
+# - The cljs-watch is just to simulate the first parameter, stating the executed
+#   command itself.
+

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (defproject cljs-watch "1.0.0-SNAPSHOT"
-  :description "FIXME: write description"
+  :description "cljs-watch automatically recompile your clourescript code"
   :main cljs-watch.core
-  :dependencies [[org.clojure/clojure "1.3.0-beta1"]
+  :dependencies [[org.clojure/clojure "1.3.0"]
+                 [org.clojure/tools.cli "0.2.1"] 
                  [cljs-compiler-jar "0.1.0-SNAPSHOT"]])

--- a/src/cljs_watch/core.clj
+++ b/src/cljs_watch/core.clj
@@ -14,9 +14,7 @@
           f (SimpleDateFormat. "HH:mm:ss")]
       (.format f (.getTime c))))
 
-  (def default-opts {:optimizations :simple
-                     :pretty-print true
-                     :output-dir "resources/public/cljs/"
+  (def default-opts {:output-dir "resources/public/cljs/"
                      :output-to "resources/public/cljs/bootstrap.js"})
 
   (def ANSI-CODES

--- a/src/cljs_watch/core.clj
+++ b/src/cljs_watch/core.clj
@@ -91,17 +91,17 @@
   (defn nop [])
   (defn- create-done-fn [argsmap]
     (if (:bell argsmap)
+      #(do (print \u0007) (flush))
       (if-let [cmd (:bell-cmd argsmap)]
         #(.exec (Runtime/getRuntime) cmd)
-        #(do (print \u0007) (flush))
-      )
-      nop))
+        nop
+      )))
 
   (defn transform-cl-args [args]
     (let [[argmap extra] (cli/cli args
             ["-s" "--source"    "Source file or directory" :default "src/"]
             ["-b" "--bell"      "Uses system beep to indicate a finished compile" :flag true]
-            ["-c" "--bell-cmd"  "Use this to customize the beep command"])
+            ["-c" "--bell-cmd"  "Use this to customize the beep command e.g. growlnotify -m compile-done cljs-watch"])
           options (parse-options extra)]
         (assoc argmap :options options)))
 
@@ -114,6 +114,7 @@
       (watcher-print "Building ClojureScript files in ::" src-dir)
       (compile-cljs src-dir opts)
       (status-print "[done]")
+      (donefn)
       (watcher-print "Waiting for changes\n")
       (while true
         (Thread/sleep 1000)

--- a/src/cljs_watch/core.clj
+++ b/src/cljs_watch/core.clj
@@ -1,5 +1,6 @@
 (use '[clojure.java.io :only [file]])
 (require '[cljs.closure :as cljsc])
+(require '[clojure.tools.cli :as cli])
 
 ;;wrap everything in a do to prevent the ouput, as a file
 ;;this is unnecessary, but from clojure.main -e it makes a 
@@ -75,26 +76,49 @@
     (print "    " (style text :green) "\n")
     (flush))
 
-  (defn transform-cl-args
-    [args]
-    (let [source (first args)
-          opts-string (apply str (interpose " " (rest args)))
-          options (when (> (count opts-string) 1)
-                    (try (read-string opts-string)
-                         (catch Exception e (println e))))]
-      {:source source :options options}))
+  (defn- parse-options [extra]
+    (let [opts-string (apply str (interpose " " extra))]
+      (if (empty? opts-string)
+        {}
+        (try (let [opts (read-string opts-string)]
+                (if (map? opts)
+                  opts
+                  (do
+                    (println "cljs options must be in map syntax")
+                    {})))
+          (catch Exception e (println e))))))
 
-  (let [{:keys [source options]} (transform-cl-args *command-line-args*)
-        src-dir (or source "src/")
-        opts (merge default-opts options)]
-    (.mkdirs (file (:output-dir opts)))
-    (watcher-print "Building ClojureScript files in ::" src-dir)
-    (compile-cljs src-dir opts)
-    (status-print "[done]")
-    (watcher-print "Waiting for changes\n")
-    (while true
-      (Thread/sleep 1000)
-      (when (files-updated? src-dir)
-        (watcher-print "Compiling updated files...")
-        (compile-cljs src-dir opts)
-        (status-print "[done]")))))
+  (defn nop [])
+  (defn- create-done-fn [argsmap]
+    (if (:bell argsmap)
+      (if-let [cmd (:bell-cmd argsmap)]
+        #(.exec (Runtime/getRuntime) cmd)
+        #(do (print \u0007) (flush))
+      )
+      nop))
+
+  (defn transform-cl-args [args]
+    (let [[argmap extra] (cli/cli args
+            ["-s" "--source"    "Source file or directory" :default "src/"]
+            ["-b" "--bell"      "Uses system beep to indicate a finished compile" :flag true]
+            ["-c" "--bell-cmd"  "Use this to customize the beep command"])
+          options (parse-options extra)]
+        (assoc argmap :options options)))
+
+  (let [
+    argsmap (transform-cl-args *command-line-args*)
+    {src-dir :source, :keys [options]} argsmap
+    donefn (create-done-fn argsmap)
+    opts (merge default-opts options)]
+      (.mkdirs (file (:output-dir opts)))
+      (watcher-print "Building ClojureScript files in ::" src-dir)
+      (compile-cljs src-dir opts)
+      (status-print "[done]")
+      (watcher-print "Waiting for changes\n")
+      (while true
+        (Thread/sleep 1000)
+        (when (files-updated? src-dir)
+          (watcher-print "Compiling updated files...")
+          (compile-cljs src-dir opts)
+          (status-print "[done]")
+          (donefn)))))


### PR DESCRIPTION
Hi there,

thanks for the great script.

I made some changes that might come in handy. I always had to wait to until the compile was done and wanted to have some kind of notification for that.

Additionally I wanted to place the clojure macro code where I want, so I changed the classpath setting to CLASSPATH since "java -cp" disables the CLASSPATH variable which makes it a log more inflexible.

Unfortunately I had a little problem with the inline version of the watch script. As you might see the cli argument parse code had to be inlined too. It works but is not so nice.
It could also be solved by setting an environment variable but I guess your goal was to have the most easy installation for it.

I would be glad if we could talk about the solution and maybe do some improvements.

regards

Benjamin
