### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ You must have ClojureScript already setup and have $CLOJURESCRIPT_HOME correctly
 Put `cljs-watch` on your $PATH (such as in /usr/local/bin) and then simply run it from your project root:
 
 ```bash
-#without options it watches the src/ directory
+# without options it watches the src/ directory
 cljs-watch
 
-#it can also take a directory and compile options
+# it can also take a directory and compile options
 cljs-watch cljs-src/ '{:optimizations :none :output-to "test.js"}'
 ```
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
